### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,3 +23,4 @@ jobs:
         node-version: 18.x
         cache: 'npm'
     - run: npm ci
+    - run: npm run generate

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,6 @@
+<template>
+    <main>
+        <ContentDoc />
+        This is the main page.
+    </main>
+</template>


### PR DESCRIPTION
Deployment fails; it requires an index page (e.g. `index.vue`) to render properly.

This PR also adds the `npm run generate` to the CI workflow, to make sure it works before being deployed from `main`.