### PR TITLE
Read in baseURL and categories from configuration file

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,8 @@
     "publicProps":
     {
     "title": "NEBULA platform",
-    "categoryOrder": ["Getting started", "Reusability", "Publishing & Citing", "Resources", "Examples"],
+    "repoName":"NEBULA",
+    "categoryOrder": ["Getting started", "Reusability", "Publishing & Citing", "Upcoming (under construction)"],
     "another": "this test worked"
     }
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,6 @@
     {
     "title": "NEBULA platform",
     "repoName":"NEBULA",
-    "categoryOrder": ["Getting started", "Reusability", "Publishing & Citing", "Upcoming (under construction)"],
-    "another": "this test worked"
+    "categoryOrder": ["Getting started", "Reusability", "Publishing & Citing", "Upcoming (under construction)"]
     }
 }

--- a/config.json
+++ b/config.json
@@ -3,6 +3,6 @@
     {
     "title": "NEBULA platform",
     "repoName":"NEBULA",
-    "categoryOrder": ["Getting started", "Reusability", "Publishing & Citing", "Upcoming (under construction)"]
+    "categoryOrder": ["Getting Started", "Reusability", "Publishing & Citing", "Upcoming (under construction)"]
     }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,6 @@
 import { publicProps } from './config.json'
 import tailwindTypography from '@tailwindcss/typography'
 
-
 export default defineNuxtConfig({
   runtimeConfig: { 
     public: publicProps, 
@@ -30,7 +29,7 @@ export default defineNuxtConfig({
     documentDriven: true
   },
   app: {
-    baseURL: '/NEBULA/'
+    baseURL: `/${publicProps.repoName}/`
   },
   generate: {
       nojekyll: true,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@
                         :key="modObject.id"
                         :title="modObject.title"
                         :author="modObject.author"
-                        :thumbnail="`/NEBULA/${modObject._path}/media/${modObject.thumbnail}`"
+                        :thumbnail="`/${runtimeConfig.public.repoName}/${modObject._path}/media/${modObject.thumbnail}`"
                         :url="modObject._path"
                     />
                 </ContentList>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
         <div class="flex flex-col pt-4 pb-6 pl-6">
             <!-- categories -->
-            <div v-for='category in ["Getting Started", "Reusability", "Resources"]' :key="category" class="flex flex-wrap gap-4 mb-8">
+            <div v-for='category in runtimeConfig.public.categoryOrder' :key="category" class="flex flex-wrap gap-4 mb-8">
                 <h2 class="prose-2xl font-display font-bold text-eSciencePurple w-full pl-2">
                 {{ category }}
                 </h2>
@@ -26,6 +26,8 @@
 
     import type { QueryBuilderParams } from '@nuxt/content/dist/runtime/types'
     
+    const runtimeConfig = useRuntimeConfig()
+
     const {
         // Global references
         globals,


### PR DESCRIPTION
This uses the config.json file to read in some variables that were previously hardcoded. We should make sure that the config.json file will be read in from the content repo in the future. 