### PR TITLE
Fix in module name rendering

### DIFF
--- a/pages/modules/[module].vue
+++ b/pages/modules/[module].vue
@@ -1,21 +1,11 @@
 <template>
     <div class="flex flex-col h-full w-full ">
 
-      <!-- Print name of the module by searching for its *.pm file and `title` field -->
-      <div class="content-container">
-        <ContentList path="/modules" :query="modQuery" v-slot="{ list }">
-          <!-- Iterate through the list to find matching modObject -->
-          <div v-for="modObject in list.filter(mo => mo._path === $route.path)" :key="modObject.id">
-            <h2 class="prose-2xl font-display font-bold text-eSciencePurple w-full pl-2">
-              Module {{ modObject.title }}
-            </h2>
-          </div>
-          <!-- Just in case: display a fallback message if the list is empty or no match -->
-          <div v-if="list.length === 0 || list.every(mo => mo._path !== $route.path)">
-            <p>No module found for this path.</p>
-          </div>
-        </ContentList>
-      </div>
+      <ContentDoc v-slot="{ doc }">
+        <h2 class="prose-2xl font-display font-bold text-eSciencePurple w-full pl-2">
+          Module {{ doc.title }}
+        </h2>
+      </ContentDoc>
 
       <div class="flex no-wrap text-left">
         <ContentList :path="'/modules/' + $route.params.module + '/'" v-slot="{ list }">
@@ -34,14 +24,3 @@
       <NuxtPage />
     </div>
 </template>
-
-<!-- Query visible modules only -->
-<script setup lang="ts">
-
-    import type { QueryBuilderParams } from '@nuxt/content/dist/runtime/types'
-
-    const runtimeConfig = useRuntimeConfig()
-
-    const modQuery: QueryBuilderParams = { path: '/modules', where: [{ visibility: 'visible' }] }
-
-</script>

--- a/pages/modules/[module].vue
+++ b/pages/modules/[module].vue
@@ -1,8 +1,21 @@
 <template>
     <div class="flex flex-col h-full w-full ">
-      <h2 class="prose-2xl font-display font-bold text-eSciencePurple w-full pl-2">
-        Module {{$route.params.module}}
-      </h2>
+
+      <!-- Print name of the module by searching for its *.pm file and `title` field -->
+      <div class="content-container">
+        <ContentList path="/modules" :query="modQuery" v-slot="{ list }">
+          <!-- Iterate through the list to find matching modObject -->
+          <div v-for="modObject in list.filter(mo => mo._path === $route.path)" :key="modObject.id">
+            <h2 class="prose-2xl font-display font-bold text-eSciencePurple w-full pl-2">
+              Module {{ modObject.title }}
+            </h2>
+          </div>
+          <!-- Just in case: display a fallback message if the list is empty or no match -->
+          <div v-if="list.length === 0 || list.every(mo => mo._path !== $route.path)">
+            <p>No module found for this path.</p>
+          </div>
+        </ContentList>
+      </div>
 
       <div class="flex no-wrap text-left">
         <ContentList :path="'/modules/' + $route.params.module + '/'" v-slot="{ list }">
@@ -21,3 +34,14 @@
       <NuxtPage />
     </div>
 </template>
+
+<!-- Query visible modules only -->
+<script setup lang="ts">
+
+    import type { QueryBuilderParams } from '@nuxt/content/dist/runtime/types'
+
+    const runtimeConfig = useRuntimeConfig()
+
+    const modQuery: QueryBuilderParams = { path: '/modules', where: [{ visibility: 'visible' }] }
+
+</script>


### PR DESCRIPTION
This PR partially addresses #32 

# Aim
Print properly the name of the modules according to their `title` field and not based on the names of the files. 
An example can be shown below for the `Software Managment Plans` module with main file named `smp.md`. Currently, it is rendered as:

![Screenshot 2024-04-26 at 13 53 18 (2)](https://github.com/esciencecenter-digital-skills/NEBULA/assets/114645116/ee55e7cc-9ff9-4d6f-be08-667dc20add26)

To avoid this, we should be able to render its `title` field instead as defined in `smp.md`:
```
---
id: 1
trl: medium
category: Reusability
title: Software Management Plans
author: eScience Center
thumbnail: "nlesc-dummy.png"
visibility: visible
---
```
![Screenshot 2024-04-26 at 13 55 28 (2)](https://github.com/esciencecenter-digital-skills/NEBULA/assets/114645116/182bb5b2-0786-4af1-89c4-f4ce8bfd97a9)

# Dificulties

Currently, in `[module].vue`, the title is defined as `Module {{$route.params.module}}` which is essentially the name of the module folder (if I inderstood well), and hence, there is not title associated with it: `{{$route.params.module.title}}` does not exist.

# Comments on the proposed solution

My solution may not be the most efficient, but I'm open to other suggestions.

## Requirements
With this proposed solution, you need to ensure that both the `*.md` file and the module folder have the same name.