### PR TITLE
Add option to disable deployment for testing jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,11 @@ on:
       base_url:
         required: false
         type: string
-
+      deploy_to_ghpages: 
+        description: 'Deploys to gh-pages branch if set to true (default). Set this to false for testing builds/generation.'
+        required: false
+        default: true
+        type: boolean
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
@@ -74,6 +78,7 @@ jobs:
           npx nuxi generate
 
       - name: Deploy
+        if: ${{ inputs.deploy_to_ghpages }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For testing the building/generation of the site in PRs (e.g. in <https://github.com/esciencecenter-digital-skills/NEBULA-content-template/pull/3>) it would be nice to be able to use the normal (reusable) deployment workflow from NEBULA, but with the option of not running the very final step (pushing to gh-pages) since we don't want to overwrite what's normally the site generated from the `main` branch.

I've added an optional `deploy_to_ghpages` input to the workflow, that defaults to `true`. For PRs we can set it to false and still check if the SSR prerendering etc works. I think this is a better and more complete check than what is in `check.yml`  currently and reuses most of the real deployment workflow.