### PR TITLE
Fix weird module card gap on firefox

### DIFF
--- a/components/ModuleCard.vue
+++ b/components/ModuleCard.vue
@@ -2,14 +2,14 @@
   <NuxtLink :to="url">
     <!-- relative parent needed for absolute positioning of svg badges-->
     <div class="relative">
+      <!-- Module card -->
       <div class="flex flex-row bg-eScienceWhite shadow-xl max-w-xl rounded-bl-3xl rounded-tr-3xl h-48">
-        <!-- Module cards -->
         <div class="prose font-display m-4 mr-10">
           <h3>
             {{ title }}
           </h3>
         </div>
-        <img :src="thumbnail" alt="module icon" class="max-w-xs rounded-tr-3xl">
+        <img :src="thumbnail" alt="module icon" class="max-w-xl rounded-tr-3xl h-48">
       </div>
     </div>
   </NuxtLink>

--- a/components/ModuleCard.vue
+++ b/components/ModuleCard.vue
@@ -9,7 +9,7 @@
             {{ title }}
           </h3>
         </div>
-        <img :src="thumbnail" alt="module icon" class="max-w-xl rounded-tr-3xl h-48">
+        <img :src="thumbnail" alt="module icon" class="max-w-xs rounded-tr-3xl h-48">
       </div>
     </div>
   </NuxtLink>


### PR DESCRIPTION
Add a fix to make thumbnails align correctly on firefox:

Before:
![Screenshot 2024-05-17 at 18-44-37 https __esciencecenter-digital-skills github io](https://github.com/esciencecenter-digital-skills/NEBULA/assets/2650951/a5e556db-10a3-40f0-85e5-450a2457dff3)

After:
![Screenshot 2024-05-17 at 18-43-57 Screenshot](https://github.com/esciencecenter-digital-skills/NEBULA/assets/2650951/5c386bda-a1f8-4286-8c31-457dc1b6bb7b)

(Checked on Chromium after the fix and now both look the same)