### PR TITLE
Fix license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,4 @@
-   Copyright 2023 Netherlands eScience Center
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-                                Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The NEBULA (Nuxt & eScience Based Universal Learning Application) framework can 
 
 NEBULA is being created as part of the Netherlands eScience Center Digital Skills programme.
 
-Copyright 2024 Netherlands eScience Center
+Copyright 2023-2024 Netherlands eScience Center
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The NEBULA (Nuxt & eScience Based Universal Learning Application) framework can 
 
 NEBULA is being created as part of the Netherlands eScience Center Digital Skills programme.
 
-Copyright 2023 Netherlands eScience Center
+Copyright 2024 Netherlands eScience Center
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/esciencecenter-digital-skills/NEBULA/blob/main/LICENSE)
+
 # NEBULA
 
 The NEBULA (Nuxt & eScience Based Universal Learning Application) framework can be used to create an easily maintainable, version-controllable, web-based lesson collection. It is based on [Nuxt.js](https://nuxtjs.org/) and [Vue.js](https://vuejs.org/).
 
 NEBULA is being created as part of the Netherlands eScience Center Digital Skills programme.
+
+Copyright 2023 Netherlands eScience Center
+
 
 ## Documentation
 


### PR DESCRIPTION
Fix #39 

- Fixes the license to use the default github apache2.0 template 
- move copyright info to readme
- Adds license badge to readme