### PR TITLE
Don't render frontmatter for chapters of type "slides" and use standard .md extension

### DIFF
--- a/components/Slides.vue
+++ b/components/Slides.vue
@@ -21,6 +21,14 @@ export default {
     },
   },
   methods: {
+    /**
+      Takes a string containing raw markdown (mdstr) and returns it with
+      the yaml frontmatter removed. It does this by deleting the first
+      instance of text between "---" separators. Currently this means that
+      if the markdown file is missing the frontmatter, this function will
+      probably remove the first slide (since reveal.js defaults to "---"
+      as a slides separator.
+    */
     stripFrontmatter (mdstr) {
       return mdstr.replace(/^---$.*?^---$/ms, '');
     },

--- a/components/Slides.vue
+++ b/components/Slides.vue
@@ -2,10 +2,12 @@
   <div class="flex relative box-border h-full reveal">
     <div class="slides flex h-full w-full">
       <section
-        :data-markdown="slidescontent"
+        data-markdown
         data-separator="^\r?\n---\r?\n$"
         data-separator-notes="^Note:"
-      />
+      >
+      {{ stripFrontmatter(slidescontent) }}
+      </section>
     </div>
   </div>
 </template>
@@ -16,6 +18,11 @@ export default {
     slidescontent: {
       type: String,
       default: "Missing Document",
+    },
+  },
+  methods: {
+    stripFrontmatter (mdstr) {
+      return mdstr.replace(/^---$.*?^---$/ms, '');
     },
   },
 };

--- a/components/Slides.vue
+++ b/components/Slides.vue
@@ -3,7 +3,8 @@
     <div class="slides flex h-full w-full">
       <section
         data-markdown
-        data-separator="^\r?\n---\r?\n$"
+        data-separator="^\r?\n===\r?\n$"
+        data-separator-vertical="^\r?\n==\r?\n$"
         data-separator-notes="^Note:"
       >
       {{ stripFrontmatter(slidescontent) }}

--- a/components/Slides.vue
+++ b/components/Slides.vue
@@ -51,8 +51,6 @@ onMounted(() => {
   // (Importing statically causes errors during server side rendering)
   if (process.browser) {
     import("reveal.js").then((revealModule) => {
-      console.log("Check", revealModule);
-
       const deck = new revealModule.default();
       deck.initialize({
         controls: true,
@@ -64,8 +62,6 @@ onMounted(() => {
         showNotes: true,
         plugins: [RevealMarkdown, RevealNotes, Decorations, Search],
       });
-
-      console.log("Check", deck);
     });
   }
 });

--- a/pages/modules/[module]/[chapter].vue
+++ b/pages/modules/[module]/[chapter].vue
@@ -1,9 +1,8 @@
 <template>
 
   <ContentDoc v-slot="{ doc }">
-    {{ doc.type }}
     <div v-if="doc.type === 'slides'" class='overflow-hidden h-full '>
-      <Slides :slidescontent="baseUrl + doc._file"/>
+      <Slides :slidescontent="doc.plainText"/>
     </div>
     
     <div v-else  class="flex justify-center items-center">

--- a/pages/modules/[module]/[chapter].vue
+++ b/pages/modules/[module]/[chapter].vue
@@ -1,7 +1,8 @@
 <template>
 
   <ContentDoc v-slot="{ doc }">
-    <div v-if="doc._extension === 'pmd'" class='overflow-hidden h-full '>
+    {{ doc.type }}
+    <div v-if="doc.type === 'slides'" class='overflow-hidden h-full '>
       <Slides :slidescontent="baseUrl + doc._file"/>
     </div>
     

--- a/server/plugins/content.ts
+++ b/server/plugins/content.ts
@@ -1,0 +1,26 @@
+// This plugin is needed to solve the current bad implementation of NuxtContent
+// that only makes the post-processed markdown available in body and drops
+// other props (added e.g. during beforeParse) so the raw markdown cannot simply
+// be passed as a custom property.
+//
+// Check e.g. https://github.com/nuxt/content/issues/2056 to see if this
+// eventually gets fixed.
+
+// The following code is the workaround proposed here:
+// https://github.com/nuxt/content/issues/2056#issuecomment-1560200992
+export default defineNitroPlugin((nitroApp) => {
+
+  let files = {}
+
+  nitroApp.hooks.hook("content:file:beforeParse", (file) => {
+    if (file._id.endsWith(".md")) {
+      files[file._id] = file.body;
+    }
+  })
+
+  nitroApp.hooks.hook("content:file:afterParse", (file) => {
+    if (file._id.endsWith(".md")) {
+      file.plainText = files[file._id];
+    }
+  })
+});


### PR DESCRIPTION
Fixes #32

This PR does two things:
1. Makes the raw markdown available to the Slides component, which then strips the yaml frontmatter before rendering with reveal.js
2. Checks the `type` value in a chapter's frontmatter. If it is `"slides"` then it goes to the `<Slides>` component; anything else goes to the standard `<ContentRenderer>` used by NuxtContent.

This is the result of trying many different ways of achieving this (various examples in Nuxt docs simply don't work as advertised or are too vaguely explained to know why things are silently failing, NuxtContent plugin does not make the raw markdown available after parsing and annoyingly ignores all custom props you might attempt to add in a custom plugin (see e.g. <https://github.com/nuxt/content/issues/2056>), reveal.js does not want to add the functionality to ignore frontmatter etc etc) so this is the least hacky way I've come up with so far.

Something we should still solve (or clearly put in the documentation if not) regards the way the frontmatter is removed. Currently I regex for the first occurrence of text between "---" separators. As this is the same as the default reveal.js slide separator, there is potential for confusion if users forget to add frontmatter to their chapters (or misformat it somehow) and wonder why the first slide of their presentation is missing. We can either change the default, document it clearly or make the `stripFrontmatter()` function more intelligent. Not sure what is best.

Note that there are node packages that claim to do the stripping but <https://www.npmjs.com/package/front-matter> is unmaintained and the replacement, <https://www.npmjs.com/package/gray-matter>, also seems no longer maintained. I did try gray-matter but got some cryptic error that I think is to do with it assuming it runs in a browser, so breaks when we do SSR. Not sure though.

Anyway, for now it seems to be working, at least locally. We should now test with deployment.

