### PR TITLE
Remove repoName config variable

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,7 +11,7 @@
                         :key="modObject.id"
                         :title="modObject.title"
                         :author="modObject.author"
-                        :thumbnail="`/${config.repoName}${modObject._path}/media/${modObject.thumbnail}`"
+                        :thumbnail="`/${config.baseURL}/${modObject._path}/media/${modObject.thumbnail}`"
                         :url="`${modObject._path}/info`"
                     />
                 </ContentList>

--- a/pages/modules/[module]/[chapter].vue
+++ b/pages/modules/[module]/[chapter].vue
@@ -19,5 +19,5 @@
   const chapterList = await queryContent('/modules/' + route.params.module + '/')
     .sort({ order: 1, $numeric: true })
     .find();
-  const baseUrl = "/" + runtimeConfig.public.repoName + "/";
+  const baseUrl = "/" + runtimeConfig.public.baseURL + "/";
 </script>


### PR DESCRIPTION
- Replace repoName with baseURL in index and chapter pages
- Remove repoName from config files (in content template and RSS repos)