### PR TITLE
Add explicit style for bullet points

### DIFF
--- a/layouts/style.scss
+++ b/layouts/style.scss
@@ -7,10 +7,17 @@
 @import url('reveal.js/dist/reveal.css');
 @import url('~/layouts/nlesc-decorations.scss');
 
-p, ul, ol{
+p {
   a{
    text-decoration: underline;
- }
+  }
+
+}
+
+ul {
+    list-style-type: disc; 
+    list-style-type: circle; 
+    list-style-position: inside; 
 }
 
 #footer{

--- a/layouts/style.scss
+++ b/layouts/style.scss
@@ -7,21 +7,36 @@
 @import url('reveal.js/dist/reveal.css');
 @import url('~/layouts/nlesc-decorations.scss');
 
-p {
-  a{
-   text-decoration: underline;
+
+@tailwind base;
+
+@layer base {
+  ul, ol, li{
+    list-style-type: revert;
   }
+  
+  p, ul{
+    a{
+      // text-decoration: revert;
+      color: #380339;
+      // text-underline-offset: 3px;
+      font-weight: bold;
+      
+    }  
+    a:after{
+      padding-right: 1em;
+      content: "";
+      background: url("~/public/icons/external-link.svg") no-repeat 0 0;
+      background-size: 100%;
+      // width: 15px;
+      // height: 15px;
+    }  
+  }  
 
-}
-
-ul {
-    list-style-type: disc; 
-    list-style-type: circle; 
-    list-style-position: inside; 
-}
-
-#footer{
-  a {
-    text-decoration: underline;
-  }
+  #footer{
+    a{
+    text-decoration: revert;  
+    }
+  }  
+  
 }

--- a/public/icons/external-link.svg
+++ b/public/icons/external-link.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6H7a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-5m-6 0 7.5-7.5M15 3h6v6"/>
+</svg>


### PR DESCRIPTION
I'm not sure what exactly is stripping away the `<ul>` element styling but setting tailwind classes with list styles was not helping. This PR at least makes the bullet points visible.