### PR TITLE
Add ability to render maths in reveal.js slides

### DIFF
--- a/components/Slides.vue
+++ b/components/Slides.vue
@@ -14,6 +14,7 @@
 </template>
 
 <script lang="ts">
+
 export default {
   props: {
     slidescontent: {
@@ -41,7 +42,6 @@ export default {
 import RevealMarkdown from "reveal.js/plugin/markdown/markdown.esm.js";
 
 import RevealNotes from "reveal.js/plugin/notes/notes.js";
-//    import RevealMath from 'reveal.js/plugin/math/math.js'
 import Search from "reveal.js/plugin/search/search.esm.js";
 import Decorations from "~/assets/nlesc-decorations.js";
 
@@ -50,18 +50,23 @@ onMounted(() => {
 
   // On client side only, dynamically load reveal.js
   // (Importing statically causes errors during server side rendering)
+  // For different (unclear) reasons, importing RevealMath alongside
+  // the other plugins causes a "Plugin not found" error if the page
+  // is reloaded. Therefore it is also imported async here.
   if (process.browser) {
     import("reveal.js").then((revealModule) => {
-      const deck = new revealModule.default();
-      deck.initialize({
-        controls: true,
-        progress: true,
-        center: true,
-        hash: true,
-        transition: "none",
-        embedded: true,
-        showNotes: true,
-        plugins: [RevealMarkdown, RevealNotes, Decorations, Search],
+      import("reveal.js/plugin/math/math.esm.js").then((RevealMath) => {
+        const deck = new revealModule.default();
+        deck.initialize({
+	  controls: true,
+	  progress: true,
+	  center: true,
+	  hash: true,
+	  transition: "none",
+	  embedded: true,
+	  showNotes: true,
+	  plugins: [RevealMarkdown, RevealMath.default, RevealNotes, Decorations, Search],
+	});
       });
     });
   }


### PR DESCRIPTION
This PR finally adds back the reveal math plugin for rendering LaTex in slides. This used to work in the old version of this framework (before porting to nuxt3) but then started failing with mysterious "Plugin not found" errors if the page was reloaded when a slide deck was present. It therefore got commented out for a long time but now I actually need to use it...

After a lot of digging, it turns out that `reveal.js/plugin/math/math.js` (or `reveal.js/plugin/math/math.esm.js`, it doesn't seem to matter) relies on a variable called `Plugin` that is used to switch between any of the 3 available LaTex backends. For a reason that have to do with js, nuxt or vite dependency caching, ssr (or who knows), this variable does not exist anymore when the page is reloaded. Note that the other internal reveal plugins all work fine on page reload so I'm not sure what is wrong.

In any case, I now import that plugin asynchronously on the client side only and that makes everything work happily again.