### PR TITLE
Add workaround to fix broken URLs due to nuxt ignoring baseURL when prerendering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Generate
         run: |
+          export NEBULA_PRERENDER=TRUE
           cd NEBULA
           npx nuxi generate
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,19 +29,35 @@ console.log(`organizationURL =`, config.organizationURL)
 if(!config.organizationURL) {
   console.log("\"organizationURL\" is not defined, default to nlesc url");
   config.organizationURL = "https://www.esciencecenter.nl";
- }
+}
 
 console.log(`organizationLogo =`, config.organizationLogo)
-if(!config.organizationLogo) {
+if(config.organizationLogo) {
+  // This is a hack required to work around the current inconsistent behaviour of baseURL,
+  // *somewhere* in the deep nuxt stack, that is still not fixed. Essentially, baseURL is
+  // ignored when prerendering static sites, but then seemingly only for certain URLs.
+  // One of those affected URLs is the one pointing to the organization logo.
+  // As a workaround, we check for a `NEBULA_PRERENDER` env var that should be set to TRUE
+  // in any builds for e.g. ghpages. This prefixes the URL with the otherwise missing
+  // baseURL.
+  //
+  // Possibly relevant issue: https://github.com/nuxt/nuxt/issues/30850
+  
+  console.log("NEBULA_PRERENDER =", process.env.NEBULA_PRERENDER)
+  if(process.env.NEBULA_PRERENDER === "TRUE") {
+    config.organizationLogo = config.baseURL + config.organizationLogo;
+    console.log(`Modified organizationLogo for pre-rendering =`, config.organizationLogo)
+  }
+} else {
   console.log("\"organizationLogo\" is not defined, default to nlesc logo");
   config.organizationLogo = "/styles/nlesc/logo.svg";
- }
+}
 
 console.log(`style =`, config.style)
 if(!config.style) {
   console.log("\"style\" is not defined, default to nlesc style");
   config.style = "nlesc";
- }
+}
 
 
 export default defineNuxtConfig({

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,8 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import tailwindTypography from '@tailwindcss/typography';
 import dotenv from 'dotenv';
-import fs from 'fs'
+import fs from 'fs';
+import path from 'path';
 
 dotenv.config();
 console.log(`Checking for content specified by CONTENT_PATH: `, process.env.CONTENT_PATH)
@@ -45,8 +46,8 @@ if(config.organizationLogo) {
   
   console.log("NEBULA_PRERENDER =", process.env.NEBULA_PRERENDER)
   if(process.env.NEBULA_PRERENDER === "TRUE") {
-    config.organizationLogo = config.baseURL + config.organizationLogo;
-    console.log(`Modified organizationLogo for pre-rendering =`, config.organizationLogo)
+    config.organizationLogo = path.join(config.baseURL, config.organizationLogo);
+    console.log(`Modified organizationLogo for pre-rendering =`, config.organizationLogo);
   }
 } else {
   console.log("\"organizationLogo\" is not defined, default to nlesc logo");


### PR DESCRIPTION
This is the latest instalment in the long running saga that is trying to get nuxt to honour `baseURL` consistently. It works with local testing (i.e. `npm run dev`) but fails for certain URLs during prerendering. Maybe it's due to nuxt, maybe nitro, maybe something else, but we don't have time to investigate it endlessly. I am adding a `NEBULA_PRERENDER` environment var that will be set to `TRUE` for any static builds (i.e. for ghpages) and that triggers a workaround to fix the broken URLs.