### PR TITLE
Fix fullscreen bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ logs
 .env
 .env.*
 !.env.example
+
+## JetBrains
+**.iml

--- a/components/Slides.vue
+++ b/components/Slides.vue
@@ -48,6 +48,8 @@ import RevealNotes from "reveal.js/plugin/notes/notes.js";
 import Search from "reveal.js/plugin/search/search.esm.js";
 import Escience from "escience_theme/escience_5.1.0.esm.js";
 
+const revealRef = ref(null);
+
 onMounted(() => {
   console.log("Slides Mounted");
 
@@ -60,6 +62,7 @@ onMounted(() => {
     import("reveal.js").then((revealModule) => {
       import("reveal.js/plugin/math/math.esm.js").then((RevealMath) => {
         const deck = new revealModule.default();
+        revealRef.value = deck;
         deck.initialize({
           controls: true,
           progress: true,
@@ -72,6 +75,13 @@ onMounted(() => {
         });
       });
     });
+  }
+});
+
+onUnmounted(() => {
+  if (revealRef.value && revealRef.value.destroy) {
+    // https://revealjs.com/initialization/#destroy
+    revealRef.value.destroy();
   }
 });
 </script>


### PR DESCRIPTION
## Fix fullscreen bug

### Changes proposed in this pull request

* Call the [reveal.js cleanup function](https://revealjs.com/initialization/#destroy) when slides are unmounted.
* Edit the `.gitignore` to include JetBrains files

**Note:** this was only tested in dev mode.

### How to test

* Run NEBULA against some content, e.g. [Research Software Support](https://github.com/esciencecenter-digital-skills/research-software-support), but I encourage you to test this with other content as well
* Go to a slide page, make it fullscreen (by pressing `F`), exit fullscreen
* Repeat this on other slides
* This should always work
* There should be no errors in the console about fullscreen
* Try this in different browsers

closes #103